### PR TITLE
update deps to compat with lastest flutter

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,12 +9,12 @@ environment:
 dependencies:
   args: ^1.6.0
   build_runner_core: ^6.0.1
-  dart_style: ^1.3.6
+  dart_style: ^2.0.1
   io: ^0.3.3
-  meta: ^1.1.8
+  meta: ^1.7.0
   path: ^1.0.0
   source_span: '>=1.0.0 <2.0.0'
-  yaml: ^2.0.0
+  yaml: ^3.1.0
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
close #3 

After digging into issue #3 , it seems that`dart_style 1.3.12` imported an transtive dependency ` analyzer 0.41.2`, which didn't compat with `meta:1.7.0`.

```log
|-- dart_style 1.3.12
|   |-- analyzer 0.41.2
|   |   |-- _fe_analyzer_shared 14.0.0
|   |   |   '-- meta...
|   |   |-- cli_util 0.3.3
|   |   |   |-- meta...
|   |   |   '-- path...
|   |   |-- args...
|   |   |-- collection...
|   |   |-- convert...
|   |   |-- crypto...
|   |   |-- glob...
|   |   |-- meta...
|   |   |-- package_config...
|   |   |-- path...
|   |   |-- pub_semver...
|   |   |-- source_span...
|   |   |-- watcher...
|   |   '-- yaml...
|   |-- pub_semver 2.0.0
|   |   '-- collection...
|   |-- args...
|   |-- path...
|   '-- source_span...
```